### PR TITLE
Typo Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifneq ($(wildcard $(MANDIR)$(EXEC).$(MANSEC)*),)
 else
 	@mkdir -p $(MANDIR)
 	@cp $(EXEC).$(MANSEC) $(MANDIR)
-	@chown 644 $(MANDIR)$(EXEC).$(MANSEC)
+	@chmod 644 $(MANDIR)$(EXEC).$(MANSEC)
 	@echo "Created man page $(MANDIR)$(EXEC).$(MANSEC)"
 endif
 # Create global config


### PR DESCRIPTION
`644` is an argument for `chmod`. Probably meant to do `chmod` instead of `chown`.