### PR TITLE
More general syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ If tspreed is terminated before the presentation has finished, the progress of t
 
 #### Install
 
+Replace github.com with gitlab.com if using GitLab
 ```
-# Replace github.com with gitlab.com if using GitLab
 $ git clone https://github.com/n-ivkovic/tspreed
 $ cd tspreed
-$ sudo make install
+# make install
 ```
 
 #### Update
 
 ```
-$ sudo make uninstall
+# make uninstall
 $ git pull origin
-$ sudo make install
+# make install
 ```
 
 #### Additional options


### PR DESCRIPTION
The install instructions specify `sudo make` for system-wide `make` commands. Different systems manage this differently and not everyone can use `sudo`, especially those not on Linux. These instructions typically give base syntax and leave it to the user to acquire the appropriate permissions. As for shell syntax when entering commands, `$` indicates a user and `#` indicates root user.