### PR TITLE
improved makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ MAN           = $(MANDIR)/$(MANFILE)
 CONFGLOBALDIR = $(DESTDIR)/etc/$(EXEC)
 CONFGLOBAL    = $(CONFGLOBALDIR)/$(EXEC).rc
 
+# Mainly for non-GNU Make
+SHELL = /bin/sh
+
 default: help
 
 install:


### PR DESCRIPTION
Some systems that aren't Linux might not have `ifeq` `endif` for make, but will have set if absent assignment, see [here](https://stackoverflow.com/questions/448910/what-is-the-difference-between-the-gnu-makefile-variable-assignments-a). Since your goal is to have this available on as many systems as possible, it's a general convention to define `SHELL` as `/bin/sh` "to avoid trouble on systems where the `SHELL` variable might be inherited from the environment," this is mainly for `make` versions that aren't GNU. See [here](https://www.gnu.org/prep/standards/html_node/Makefile-Basics.html#Makefile-Basics).

EDIT:
I also simplified calls to `DESTDIR` in an amended commit.