### PR TITLE
Quick fix for "usleep is deprecated" warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# tspreed
+# Tspreed but without the "usleep is deprecated, and will be removed in near future!" warning.
+
+**Note: NOT TESTED**
+
+Why?
+
+I wanted to get rid of the warning.
+
+"warning: usleep is deprecated, and will be removed in near future!"
+
+"warning: use "sleep 1e-06" instead..."
+
+Fix:
+
+Replace "usleep" with "sleep 1e-06".
 
 tspreed is a terminal RSVP speed reader with Spritz-like functionality written in POSIX-compliant shell. It reads plain text from `stdin` and presents it one word at time.
 
@@ -7,16 +21,6 @@ If tspreed is terminated before the presentation has finished, the progress of t
 ![tspreed demo gif](.img/tspreed.gif)
 
 ## Installation
-
-### Packages
-
-| Distro | Package | Maintainer |
-| ---    | ---     | ---        |
-| Arch Linux | [tspreed (AUR)](https://aur.archlinux.org/packages/tspreed/) | Nicholas Ivkovic |
-
-### Manual
-
-#### Install
 
 Replace `github.com` with `gitlab.com` if using GitLab.
 ```

--- a/tspreed
+++ b/tspreed
@@ -190,10 +190,10 @@ IFS="$(printf "%s%b" "$IFS" "$separators")"
 
 # Determine non-POSIX capabilities
 sleep 0.0 2>/dev/null && non_posix_sleep=true || non_posix_sleep=false
-[ -n "$(command -v usleep)" ] && non_posix_usleep=true || non_posix_usleep=false
+[ -n "$(command -v sleep 1e-06)" ] && non_posix_sleep=true || non_posix_sleep=false
 ! [ "$(date "+%N")" = "%N" ] 2>/dev/null && non_posix_date_n=true || non_posix_date_n=false
 ! [ "$(date "+%s")" = "%s" ] 2>/dev/null && non_posix_date_s=true || non_posix_date_s=false
-[ "$non_posix_sleep" = false ] && [ "$non_posix_usleep" = false ] && [ "$non_posix_date_n" = false ] && exit_err 2 "System does not support at least one of required non-POSIX features or commands"
+[ "$non_posix_sleep" = false ] && [ "$non_posix_sleep 1e-06" = false ] && [ "$non_posix_date_n" = false ] && exit_err 2 "System does not support at least one of required non-POSIX features or commands"
 
 # Determine terminal capabilities
 term_reset="$(tput sgr0 2>/dev/null || printf "%b[m" "\033")"
@@ -327,8 +327,8 @@ for word in $input; do
 
 	# Sleep
 	[ "$sleep_time_int" -gt 0 ] && {
-		if [ "$non_posix_usleep" = true ]; then
-			usleep $((sleep_time_int * 1000))
+		if [ "$non_posix_sleep 1e-06" = true ]; then
+			sleep 1e-06 $((sleep_time_int * 1000))
 		elif [ "$non_posix_sleep" = true ]; then
 			sleep "$(calc_float "${sleep_time_float} / 1000")"
 		elif [ "$non_posix_date_n" = true ]; then


### PR DESCRIPTION
I'm currently running Fedora 36 and I get this warning:

warning: usleep is deprecated, and will be removed in near future!
warning: use "sleep 1e-06" instead...

This is a quick and lazy fix.

I barely tested it.

It works fine with no options at least.

I don't recommend you merging this but you should look into it.