### PR TITLE
Fix sleep_ms was always 0 while using bc ...

### DIFF
--- a/tspreed
+++ b/tspreed
@@ -125,7 +125,7 @@ get_substr() {
 # $1 calculation to perform
 calc_float() {
 	if [ "$use_bc" = true ]; then
-		printf "%s\n" "$1" | bc
+		printf "scale=1; %s\n" "$1" | bc
 	else
 		awk "BEGIN { print ${1} }"
 	fi


### PR DESCRIPTION
If `$use_bc` is true, and the `$lenghtvary` option is set to true, the sleep time of words smaller than `$word_len_average` was always `0`.

# Minimal Example

Just taking the relevant parts of the script:

```bash
#!/bin/bash

use_bc=true

calc_float() {
	if [ "$use_bc" = true ]; then
		printf "%s\n" "$1" | bc
	else
		awk "BEGIN { print ${1} }"
	fi
}

wpm=500
lengthvary=true
word_len_average=5
word_len=4

sleep_ms_float=$(calc_float "1000 / (${wpm} / 60)")
[ "$lengthvary" = true ] && sleep_ms_float="$(calc_float "${sleep_ms_float} * ($([ "$word_len" -gt "$word_len_average" ] && echo "$word_len" || echo $((word_len_average - 1))) / ${word_len_average})")"

sleep_ms="${sleep_ms_float%.*}"
[ "$(printf "%s" "$sleep_ms" | cut -c 1)" = "-" ] && sleep_ms=0

echo "sleep_ms: $sleep_ms"
```
Will output `0`. If you comment `use_bc=true` then the output will be `96`.

# Fix

Set the `scale` variable inside of `bc` to anything other than `0`. If not, `(word_len_average - 1) / word_len_average` will always return 0.

```bash
$ echo "4 / 5" | bc
0
$ echo "scale=1; 4 / 5" | bc
0.8
```
